### PR TITLE
Updated dependencies. Fixed most warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bindings/
 build/
+
+.idea/

--- a/contracts/Foo.sol
+++ b/contracts/Foo.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.4;
 
 contract Foo {
 
-    function bar() constant returns (int) {
+    function bar() constant public returns (int) {
         return 1337;
     }
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,15 +8,15 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  function Migrations() public {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) restricted {
+  function upgrade(address new_address) public restricted {
     Migrations upgraded = Migrations(new_address);
     upgraded.setCompleted(last_completed_migration);
   }

--- a/contracts/MyToken.sol
+++ b/contracts/MyToken.sol
@@ -25,7 +25,7 @@ contract MyToken {
         string tokenName,
         uint8 decimalUnits,
         string tokenSymbol
-        ) {
+        ) public {
         balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens
         totalSupply = initialSupply;                        // Update total supply
         name = tokenName;                                   // Set the name for display purposes
@@ -46,7 +46,7 @@ contract MyToken {
     /// @notice Send `_value` tokens to `_to` from your account
     /// @param _to The address of the recipient
     /// @param _value the amount to send
-    function transfer(address _to, uint256 _value) {
+    function transfer(address _to, uint256 _value) public {
         _transfer(msg.sender, _to, _value);
     }
 
@@ -54,7 +54,7 @@ contract MyToken {
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _value the amount to send
-    function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {
         require (_value < allowance[_from][msg.sender]);     // Check allowance
         allowance[_from][msg.sender] -= _value;
         _transfer(_from, _to, _value);
@@ -64,7 +64,7 @@ contract MyToken {
     /// @notice Allows `_spender` to spend no more than `_value` tokens in your behalf
     /// @param _spender The address authorized to spend
     /// @param _value the max amount they can spend
-    function approve(address _spender, uint256 _value)
+    function approve(address _spender, uint256 _value) public
         returns (bool success) {
         allowance[msg.sender][_spender] = _value;
         return true;
@@ -74,7 +74,7 @@ contract MyToken {
     /// @param _spender The address authorized to spend
     /// @param _value the max amount they can spend
     /// @param _extraData some extra information to send to the approved contract
-    function approveAndCall(address _spender, uint256 _value, bytes _extraData)
+    function approveAndCall(address _spender, uint256 _value, bytes _extraData) public
         returns (bool success) {
         tokenRecipient spender = tokenRecipient(_spender);
         if (approve(_spender, _value)) {
@@ -85,7 +85,7 @@ contract MyToken {
 
     /// @notice Remove `_value` tokens from the system irreversibly
     /// @param _value the amount of money to burn
-    function burn(uint256 _value) returns (bool success) {
+    function burn(uint256 _value) public returns (bool success) {
         require (balanceOf[msg.sender] > _value);            // Check if the sender has enough
         balanceOf[msg.sender] -= _value;                      // Subtract from the sender
         totalSupply -= _value;                                // Updates totalSupply
@@ -93,7 +93,7 @@ contract MyToken {
         return true;
     }
 
-    function burnFrom(address _from, uint256 _value) returns (bool success) {
+    function burnFrom(address _from, uint256 _value) public returns (bool success) {
         require(balanceOf[_from] >= _value);                // Check if the targeted balance is enough
         require(_value <= allowance[_from][msg.sender]);    // Check allowance
         balanceOf[_from] -= _value;                         // Subtract from the targeted balance

--- a/main.go
+++ b/main.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swarmdotmarket/perigord/contract"
-	"github.com/swarmdotmarket/perigord/migration"
+	"github.com/polyswarm/perigord/contract"
+	"github.com/polyswarm/perigord/migration"
 
-	"github.com/swarmdotmarket/token_example/bindings"
-	_ "github.com/swarmdotmarket/token_example/migrations"
+	"github.com/polyswarm/token_example/bindings"
+	_ "github.com/polyswarm/token_example/migrations"
 )
 
 func main() {

--- a/migrations/1_Migrations.go
+++ b/migrations/1_Migrations.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/swarmdotmarket/perigord/contract"
-	"github.com/swarmdotmarket/perigord/migration"
+	"github.com/polyswarm/perigord/contract"
+	"github.com/polyswarm/perigord/migration"
 
-	"github.com/swarmdotmarket/token_example/bindings"
+	"github.com/polyswarm/token_example/bindings"
 )
 
 type MigrationsDeployer struct{}

--- a/migrations/2_Foo.go
+++ b/migrations/2_Foo.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/swarmdotmarket/perigord/contract"
-	"github.com/swarmdotmarket/perigord/migration"
+	"github.com/polyswarm/perigord/contract"
+	"github.com/polyswarm/perigord/migration"
 
-	"github.com/swarmdotmarket/token_example/bindings"
+	"github.com/polyswarm/token_example/bindings"
 )
 
 type FooDeployer struct{}

--- a/migrations/3_MyToken.go
+++ b/migrations/3_MyToken.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/swarmdotmarket/perigord/contract"
-	"github.com/swarmdotmarket/perigord/migration"
+	"github.com/polyswarm/perigord/contract"
+	"github.com/polyswarm/perigord/migration"
 
-	"github.com/swarmdotmarket/token_example/bindings"
+	"github.com/polyswarm/token_example/bindings"
 )
 
 type MyTokenDeployer struct{}

--- a/perigord.yaml
+++ b/perigord.yaml
@@ -1,2 +1,2 @@
-project: github.com/swarmdotmarket/token_example
+project: github.com/polyswarm/token_example
 license: Apache 2.0

--- a/stub/README.md
+++ b/stub/README.md
@@ -1,7 +1,7 @@
 # Perigord stub
 
 This file just serves as an entry point for the
-github.com/swarmdotmarket/perigord/stub command, which serves as a driver for
+github.com/polyswarm/perigord/stub command, which serves as a driver for
 perigord subcommands such as test and deploy which must link against your
 migrations and tests.
 

--- a/stub/main.go
+++ b/stub/main.go
@@ -3,8 +3,8 @@
 package main
 
 import (
-	_ "github.com/swarmdotmarket/token_example/migrations"
-	"github.com/swarmdotmarket/perigord/stub"
+	_ "github.com/polyswarm/token_example/migrations"
+	"github.com/polyswarm/perigord/stub"
 )
 
 func main() {

--- a/stub_test.go
+++ b/stub_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	_ "github.com/swarmdotmarket/token_example/tests"
-	_ "github.com/swarmdotmarket/token_example/migrations"
+	_ "github.com/polyswarm/token_example/tests"
+	_ "github.com/polyswarm/token_example/migrations"
 	. "gopkg.in/check.v1"
 )
 

--- a/tests/Foo.go
+++ b/tests/Foo.go
@@ -3,10 +3,10 @@ package tests
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/swarmdotmarket/perigord/contract"
-	"github.com/swarmdotmarket/perigord/testing"
+	"github.com/polyswarm/perigord/contract"
+	"github.com/polyswarm/perigord/testing"
 
-	"github.com/swarmdotmarket/token_example/bindings"
+	"github.com/polyswarm/token_example/bindings"
 )
 
 type foo_test struct{}

--- a/tests/MyToken.go
+++ b/tests/MyToken.go
@@ -4,10 +4,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/swarmdotmarket/perigord/contract"
-	"github.com/swarmdotmarket/perigord/testing"
+	"github.com/polyswarm/perigord/contract"
+	"github.com/polyswarm/perigord/testing"
 
-	"github.com/swarmdotmarket/token_example/bindings"
+	"github.com/polyswarm/token_example/bindings"
 )
 
 type MyTokenSuite struct {


### PR DESCRIPTION
This is a pull request to get the code to compile when `perigord build` is run. This does not fix the isses when `perigord test` is run. This is related to the fact that this example is using an old version of perigord that has a different signature for the ContractDeployer interface. Here's the stack trace:

```
$ perigord test
# github.com/polyswarm/token_example/migrations
migrations/1_Migrations.go:59:57: cannot use MigrationsDeployer literal (type *MigrationsDeployer) as type contract.ContractDeployer in argument to contract.AddContract:
	*MigrationsDeployer does not implement contract.ContractDeployer (wrong type for Bind method)
		have Bind(context.Context, *bind.TransactOpts, bind.ContractBackend, common.Address) (interface {}, error)
		want Bind(context.Context, *network.Network, common.Address) (interface {}, error)
migrations/1_Migrations.go:63:4: cannot use func literal (type func(context.Context, *bind.TransactOpts, bind.ContractBackend) error) as type migration.MigrationFunc in field value
migrations/1_Migrations.go:64:29: too many arguments in call to contract.Deploy
	have (context.Context, string, *bind.TransactOpts, bind.ContractBackend)
	want (context.Context, string, *network.Network)
migrations/2_Foo.go:59:43: cannot use FooDeployer literal (type *FooDeployer) as type contract.ContractDeployer in argument to contract.AddContract:
	*FooDeployer does not implement contract.ContractDeployer (wrong type for Bind method)
		have Bind(context.Context, *bind.TransactOpts, bind.ContractBackend, common.Address) (interface {}, error)
		want Bind(context.Context, *network.Network, common.Address) (interface {}, error)
migrations/2_Foo.go:63:4: cannot use func literal (type func(context.Context, *bind.TransactOpts, bind.ContractBackend) error) as type migration.MigrationFunc in field value
migrations/2_Foo.go:64:29: too many arguments in call to contract.Deploy
	have (context.Context, string, *bind.TransactOpts, bind.ContractBackend)
	want (context.Context, string, *network.Network)
migrations/3_MyToken.go:60:51: cannot use MyTokenDeployer literal (type *MyTokenDeployer) as type contract.ContractDeployer in argument to contract.AddContract:
	*MyTokenDeployer does not implement contract.ContractDeployer (wrong type for Bind method)
		have Bind(context.Context, *bind.TransactOpts, bind.ContractBackend, common.Address) (interface {}, error)
		want Bind(context.Context, *network.Network, common.Address) (interface {}, error)
migrations/3_MyToken.go:64:4: cannot use func literal (type func(context.Context, *bind.TransactOpts, bind.ContractBackend) error) as type migration.MigrationFunc in field value
migrations/3_MyToken.go:65:29: too many arguments in call to contract.Deploy
	have (context.Context, string, *bind.TransactOpts, bind.ContractBackend)
	want (context.Context, string, *network.Network)
Error: [exit status 2]
```